### PR TITLE
rsi-launcher: unset ELECTRON_RUN_AS_NODE in launch script

### DIFF
--- a/pkgs/rsi-launcher/default.nix
+++ b/pkgs/rsi-launcher/default.nix
@@ -127,6 +127,11 @@ in
       ''
         #!${lib.getExe bash}
         set -x
+        # RSI Launcher is an Electron app with the run_as_node fuse enabled;
+        # if ELECTRON_RUN_AS_NODE leaks in from an Electron-based host
+        # (e.g. a VSCode integrated terminal), the launcher starts as a plain
+        # Node.js runtime and exits silently with no window. Never propagate it.
+        unset ELECTRON_RUN_AS_NODE
         export PATH="${lib.makeBinPath finalAttrs.buildInputs}:$PATH"
         # Winetricks is a pinned version, this isnt needed...
         export WINETRICKS_LATEST_VERSION_CHECK=disabled


### PR DESCRIPTION
RSI Launcher is an Electron application with the `run_as_node` fuse enabled. When `ELECTRON_RUN_AS_NODE=1` is present in the caller's environment — which is the case in any Electron-based host such as a VSCode integrated terminal — the variable propagates through `umu-run` → pressure-vessel → wine into the launcher process. The launcher then boots as a plain Node.js runtime, never executes its application code, and exits silently on stdin EOF.

Symptom: `rsi-launcher` "flash-quits" with no window and no error message, while the exact same command works from a plain terminal. This is very confusing to debug (I initially suspected pressure-vessel).

Diagnosed on NixOS by differential testing: a minimal Electron app inside the same prefix quits instantly with the variable set and opens a window with `env -u ELECTRON_RUN_AS_NODE`; same behavior with the real launcher.

The launcher never legitimately needs this variable, so unset it unconditionally at the top of the launch script.
